### PR TITLE
feat: add cloud run federated user

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ This project is licensed under the **MIT license**, allowing for flexibility and
 |------|------|
 | [google_artifact_registry_repository.brainwave](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository) | resource |
 | [google_artifact_registry_repository_iam_member.brainwave-writer-deploy-ai-api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
+| [google_billing_budget.dev_budget](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_budget) | resource |
 | [google_project_iam_member.cloudrun-developer-deploy-ai-api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github-actions-artifacts-binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_service.enable_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_pubsub_topic.billing_alerts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ This project is licensed under the **MIT license**, allowing for flexibility and
 
 | Name | Type |
 |------|------|
+| [google_artifact_registry_repository.brainwave](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository) | resource |
+| [google_artifact_registry_repository_iam_member.brainwave-writer-deploy-ai-api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
+| [google_project_iam_member.cloudrun-developer-deploy-ai-api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github-actions-artifacts-binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "google_project_iam_member" "github-actions-artifacts-binding" {
 }
 
 resource "google_artifact_registry_repository" "brainwave" {
-  provider      = google
+  project       = var.landing_project_id
   location      = var.gcp_region
   repository_id = "brainwave"
   format        = "DOCKER"
@@ -41,6 +41,7 @@ resource "google_artifact_registry_repository_iam_member" "brainwave-writer-depl
     module.github-identity-federation,
     google_artifact_registry_repository.brainwave
   ]
+  project    = var.landing_project_id
   location   = google_artifact_registry_repository.brainwave.location
   repository = google_artifact_registry_repository.brainwave.name
   role       = "roles/artifactregistry.writer"


### PR DESCRIPTION
This pull request introduces new resources in the Terraform configuration to support container artifact management and permissions for AI backend deployment. The changes focus on creating a new Artifact Registry repository and assigning IAM roles for deployment service accounts.

### New Resource Additions:

* **Artifact Registry Repository**: Added a `google_artifact_registry_repository` resource named `brainwave` to manage Docker container artifacts for the AI backend. This repository is located in the specified GCP region and uses the "STANDARD_REPOSITORY" mode.

* **Artifact Registry IAM Role**: Added a `google_artifact_registry_repository_iam_member` resource to grant `roles/artifactregistry.writer` permissions to the `deploy-ai-api` service account for the `brainwave` repository. This ensures the service account can write to the repository.

* **Cloud Run IAM Role**: Added a `google_project_iam_member` resource to assign the `roles/run.admin` role to the `deploy-ai-api` service account, enabling it to manage Cloud Run services in the specified project.