### PR TITLE
fix: add missing variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This project is licensed under the **MIT license**, allowing for flexibility and
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id) | The ID of the GCP billing account to associate budgets and resources with | `string` | n/a | yes |
 | <a name="input_federated_github_users"></a> [federated\_github\_users](#input\_federated\_github\_users) | The Github users to federate. | <pre>map(object({<br>    name                 = string<br>    display_name         = string<br>    description          = string<br>    allowed-repositories = list(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_gcp_region"></a> [gcp\_region](#input\_gcp\_region) | The region in which the resources will be provisioned. | `string` | `"us-central1"` | no |
 | <a name="input_landing_identity_pool_id"></a> [landing\_identity\_pool\_id](#input\_landing\_identity\_pool\_id) | The ID of the Identity pool. | `string` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,9 @@ variable "federated_github_users" {
   description = "The Github users to federate."
   sensitive   = false
 }
+
+variable "billing_account_id" {
+  description = "The ID of the GCP billing account to associate budgets and resources with"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
This pull request introduces a new variable to the Terraform configuration to support billing account management in GCP.

### New Variable Addition:
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR42-R47): Added a new variable `billing_account_id` to store the GCP billing account ID. This variable is of type `string`, marked as sensitive, and includes a description for clarity.