### PR TITLE
feat(naming-standard): add module to enforce naming standards for service accounts

### DIFF
--- a/modules/named_sa/README.md
+++ b/modules/named_sa/README.md
@@ -1,0 +1,55 @@
+# GCP Service Account Naming Enforcer 🛡️ (Terraform Module)
+
+This module enforces a consistent naming standard for Google Cloud Platform Service Accounts. It generates and validates `account_id`s according to predefined rules, ensuring compliance with GCP's 30-character limit and promoting clear resource identification across your infrastructure.
+
+## The Standard: Required Format 🎯
+
+All Service Accounts will adhere to this format:
+
+`[domain]-[component]-[purpose]-[env]-[suffix]`
+
+### Component Breakdown:
+
+*   **`[domain]`**: Identifies the primary logical grouping, application, or stack (e.g., `apps`, `ml`, `admin`). Abbreviate only if the total name exceeds 30 characters. Ensure consistency in abbreviations. 🧠
+*   **`[component]`**: Describes the specific service, microservice, or function utilizing this SA (e.g., `web-fe`, `data-proc`, `llm-proxy`). **This is the FIRST component to abbreviate** if the total name approaches or exceeds the 30-character limit.
+*   **`[purpose]`**: Indicates the SA's primary role or critical permissions (e.g., `reader`, `invoker`, `admin`). **This is the SECOND component to abbreviate** if shortening `[component]` was insufficient. Use clear abbreviations (`read`, `exec`).
+*   **`[env]`**: Identifies the environment (e.g., `prod`, `stg`, `dev`).
+*   **`[suffix]`**: Explicitly marks the resource type based on `sa_type`.
+    *   `-sa`: For standard Service Accounts.
+    *   `-federated-user`: For Service Accounts used with Workload Identity Federation.
+
+### Naming Process:
+
+1.  Draft the full name using all components.
+2.  **Validate the length.** If `<= 30 characters`, proceed.
+3.  **If `> 30 characters`:**
+    1.  Abbreviate `[component]` as much as possible while retaining clarity.
+    2.  If still exceeding 30 characters, then abbreviate `[domain]`.
+    3.  As a final resort, abbreviate `[purpose]`.
+
+## Enforcement Rules:
+
+This module validates generated `account_id`s against strict rules:
+
+*   **30-Character Limit:** Terraform will fail if any generated `account_id` exceeds GCP's 30-character limit. The error message will explicitly state the offending name and its length. The responsibility for abbreviation to meet this limit lies with the user's input. 💥
+*   **Suffix Control:** The `sa_type` variable determines the correct suffix. The `add_suffix_by_this_module` variable allows bypassing suffix generation by this module if an external process handles it. However, the 30-character validation will still apply to the resulting name. 🧠
+
+## How to Use:
+
+Provide a map of your Service Account definitions. This module will return a map of validated `account_id`s. These IDs are then used to instantiate `google_service_account` resources.
+
+## Inputs:
+
+*   `service_accounts` (map of objects): A map of Service Account definitions. Each object requires:
+    *   `domain` (string): The primary logical grouping or application stack
+    *   `component` (string): The specific service or microservice
+    *   `purpose` (string): The Service Account's primary role or permissions
+    *   `env` (string): The environment identifier
+    *   `sa_type` (string, optional, default `standard`): Allowed values: `"standard"` or `"federated"`.
+    *   `add_suffix_by_this_module` (bool, optional, default `true`): Set to `false` if the suffix is managed externally.
+    *   `description` (string, optional): Used for the final `google_service_account` resource's description.
+    *   `labels` (map, optional): Used for the final `google_service_account` resource's labels.
+
+## Outputs:
+
+*   `service_account_ids` (map of strings): A map containing all generated `account_id`s, validated against the 30-character limit. These are ready for use in creating `google_service_account` resources.

--- a/modules/named_sa/main.tf
+++ b/modules/named_sa/main.tf
@@ -1,0 +1,22 @@
+locals {
+  suffix_map = {
+    "standard"  = "-sa"
+    "federated" = "-federated-user"
+  }
+
+  calculated_account_ids = {
+    for key, sa_params in var.service_accounts : key => {
+      calculated_suffix = sa_params.add_suffix_by_this_module ? lookup(local.suffix_map, sa_params.sa_type, "-sa") : ""
+      account_id        = "${sa_params.domain}-${sa_params.component}-${sa_params.purpose}-${sa_params.env}${calculated_suffix}"
+    }
+  }
+
+  validation_result = {
+    for key, config in local.calculated_account_ids : key => {
+      account_id = config.account_id
+      is_valid  = length(config.account_id) <= 30
+    }
+  }
+
+  _validation_check = alltrue([for k, v in local.validation_result : v.is_valid]) ? null : file("ERROR: Service Account ID length validation failed. Review the following IDs that exceed GCP's 30-character limit:\n${join("\n", [for k, v in local.validation_result : !v.is_valid ? "  - '${v.account_id}' (key: '${k}') - ${length(v.account_id)} chars" : ""])}\n\nReview 'domain', 'component', and 'purpose' for required abbreviations in your input, or consider setting 'add_suffix_by_this_module = false' if an external suffix is intended.")
+}

--- a/modules/named_sa/outputs.tf
+++ b/modules/named_sa/outputs.tf
@@ -1,0 +1,21 @@
+output "service_account_ids" {
+  description = "A map of generated service account IDs, validated against GCP's 30-character limit. Use these IDs to create the actual Service Accounts."
+  value = {
+    for key, config in local.calculated_account_ids : key => config.account_id
+  }
+}
+
+output "service_account_configs" {
+  description = "Complete service account configurations including calculated IDs and metadata."
+  value = local.calculated_account_ids
+}
+
+output "validation_summary" {
+  description = "Summary of validation results for all service account IDs."
+  value = {
+    total_accounts = length(local.calculated_account_ids)
+    valid_accounts = length([for k, v in local.validation_result : v if v.is_valid])
+    invalid_accounts = length([for k, v in local.validation_result : v if !v.is_valid])
+    invalid_ids = [for k, v in local.validation_result : v.account_id if !v.is_valid]
+  }
+}

--- a/modules/named_sa/variables.tf
+++ b/modules/named_sa/variables.tf
@@ -1,0 +1,48 @@
+variable "service_accounts" {
+  description = "A map of service account configurations, where keys are logical identifiers for each SA."
+  type = map(object({
+    domain            = string
+    component         = string
+    purpose           = string
+    env               = string
+    description       = optional(string)
+    labels            = optional(map(string))
+    sa_type           = optional(string, "standard")
+    add_suffix_by_this_module = optional(bool, true)
+  }))
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : contains(["standard", "federated-user"], sa_config.sa_type)
+    ])
+    error_message = "Each 'sa_type' must be either 'standard' or 'federated-user'."
+  }
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : length(sa_config.domain) > 0
+    ])
+    error_message = "Domain cannot be empty for any service account."
+  }
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : length(sa_config.component) > 0
+    ])
+    error_message = "Component cannot be empty for any service account."
+  }
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : length(sa_config.purpose) > 0
+    ])
+    error_message = "Purpose cannot be empty for any service account."
+  }
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : length(sa_config.env) > 0
+    ])
+    error_message = "Environment cannot be empty for any service account."
+  }
+}


### PR DESCRIPTION

This pull request introduces a new Terraform module for enforcing a consistent naming standard for Google Cloud Platform (GCP) Service Accounts. The module ensures compliance with GCP's 30-character limit, validates naming conventions, and provides outputs for service account IDs and configurations. Key changes include the addition of naming rules, validation logic, and outputs for service account management.

### Documentation Updates:
* Added comprehensive documentation in `modules/named_sa/README.md` detailing the naming standard, enforcement rules, and usage instructions for the module. This includes the required format for Service Account names and a step-by-step process for validation.

### Core Logic Implementation:
* Defined local variables in `modules/named_sa/main.tf` to calculate Service Account IDs based on user input, enforce suffix rules, and validate IDs against the 30-character limit. Added logic to generate error messages for invalid IDs.

### Outputs for User Accessibility:
* Added outputs in `modules/named_sa/outputs.tf` to expose validated Service Account IDs, complete configurations, and a summary of validation results (e.g., total, valid, and invalid accounts).

### Input Validation:
* Introduced input validation in `modules/named_sa/variables.tf` to ensure required fields (`domain`, `component`, `purpose`, `env`) are non-empty and that `sa_type` values are restricted to `"standard"` or `"federated-user"`.