### PR TITLE
Develop

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,9 +22,20 @@ resource "google_project_service" "enable_apis" {
 module "github-identity-federation" {
   source                   = "./modules/github-identity-federation"
   project-id               = var.landing_project_id
-  federated-github-users   = var.federated_github_users
+  federated-github-users   = merge(
+    var.legacy_federated_github_users,
+    {
+      for key, user in var.federated_github_users : key => {
+        name                 = module.federated_users.service_account_ids[key]
+        display_name         = user.display_name
+        description          = user.description
+        allowed-repositories = user.allowed-repositories
+      }
+    }
+  )
   landing-identity-pool-id = var.landing_identity_pool_id
   identity-provider-id     = var.landing_identity_provider_id
+  depends_on               = [module.federated_users]
 }
 
 module "mlops" {
@@ -32,6 +43,14 @@ module "mlops" {
   region     = var.gcp_region
   project-id = var.landing_project_id
 }
+
+# Federated users using named_sa module
+module "federated_users" {
+  source = "./modules/named_sa"
+  service_accounts = var.federated_service_accounts
+}
+
+
 
 resource "google_project_iam_member" "github-actions-artifacts-binding" {
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -44,10 +44,20 @@ module "mlops" {
   project-id = var.landing_project_id
 }
 
-# Federated users using named_sa module
+# Federated users using named_sa module (only for users with named_sa config)
 module "federated_users" {
   source = "./modules/named_sa"
-  service_accounts = var.federated_service_accounts
+  service_accounts = {
+    for key, user in var.federated_github_users : key => {
+      domain            = user.domain
+      component         = user.component
+      purpose           = user.purpose
+      env               = user.env
+      description       = user.description
+      sa_type           = user.sa_type
+      add_suffix_by_this_module = user.add_suffix_by_this_module
+    } if user.domain != null
+  }
 }
 
 

--- a/modules/github-identity-federation/federated-github-user/main.tf
+++ b/modules/github-identity-federation/federated-github-user/main.tf
@@ -1,5 +1,5 @@
 resource "google_service_account" "federated-user" {
-  account_id   = "${var.name}-federated-user"
+  account_id   = can(regex("-fa$", var.name)) ? var.name : "${var.name}-federated-user"
   display_name = "${var.display_name} Federated User"
   description  = "Service account for ${var.display_name} Federated User that ${var.description}"
   project      = var.project-id

--- a/modules/named_sa/README.md
+++ b/modules/named_sa/README.md
@@ -1,0 +1,55 @@
+# GCP Service Account Naming Enforcer 🛡️ (Terraform Module)
+
+This module enforces a consistent naming standard for Google Cloud Platform Service Accounts. It generates and validates `account_id`s according to predefined rules, ensuring compliance with GCP's 30-character limit and promoting clear resource identification across your infrastructure.
+
+## The Standard: Required Format 🎯
+
+All Service Accounts will adhere to this format:
+
+`[domain]-[component]-[purpose]-[env]-[suffix]`
+
+### Component Breakdown:
+
+*   **`[domain]`**: Identifies the primary logical grouping, application, or stack (e.g., `apps`, `ml`, `admin`). Abbreviate only if the total name exceeds 30 characters. Ensure consistency in abbreviations. 🧠
+*   **`[component]`**: Describes the specific service, microservice, or function utilizing this SA (e.g., `web-fe`, `data-proc`, `llm-proxy`). **This is the FIRST component to abbreviate** if the total name approaches or exceeds the 30-character limit.
+*   **`[purpose]`**: Indicates the SA's primary role or critical permissions (e.g., `reader`, `invoker`, `admin`). **This is the SECOND component to abbreviate** if shortening `[component]` was insufficient. Use clear abbreviations (`read`, `exec`).
+*   **`[env]`**: Identifies the environment (e.g., `prod`, `stg`, `dev`).
+*   **`[suffix]`**: Explicitly marks the resource type based on `sa_type`.
+    *   `-sa`: For standard Service Accounts.
+    *   `-federated-user`: For Service Accounts used with Workload Identity Federation.
+
+### Naming Process:
+
+1.  Draft the full name using all components.
+2.  **Validate the length.** If `<= 30 characters`, proceed.
+3.  **If `> 30 characters`:**
+    1.  Abbreviate `[component]` as much as possible while retaining clarity.
+    2.  If still exceeding 30 characters, then abbreviate `[domain]`.
+    3.  As a final resort, abbreviate `[purpose]`.
+
+## Enforcement Rules:
+
+This module validates generated `account_id`s against strict rules:
+
+*   **30-Character Limit:** Terraform will fail if any generated `account_id` exceeds GCP's 30-character limit. The error message will explicitly state the offending name and its length. The responsibility for abbreviation to meet this limit lies with the user's input. 💥
+*   **Suffix Control:** The `sa_type` variable determines the correct suffix. The `add_suffix_by_this_module` variable allows bypassing suffix generation by this module if an external process handles it. However, the 30-character validation will still apply to the resulting name. 🧠
+
+## How to Use:
+
+Provide a map of your Service Account definitions. This module will return a map of validated `account_id`s. These IDs are then used to instantiate `google_service_account` resources.
+
+## Inputs:
+
+*   `service_accounts` (map of objects): A map of Service Account definitions. Each object requires:
+    *   `domain` (string): The primary logical grouping or application stack
+    *   `component` (string): The specific service or microservice
+    *   `purpose` (string): The Service Account's primary role or permissions
+    *   `env` (string): The environment identifier
+    *   `sa_type` (string, optional, default `standard`): Allowed values: `"standard"` or `"federated"`.
+    *   `add_suffix_by_this_module` (bool, optional, default `true`): Set to `false` if the suffix is managed externally.
+    *   `description` (string, optional): Used for the final `google_service_account` resource's description.
+    *   `labels` (map, optional): Used for the final `google_service_account` resource's labels.
+
+## Outputs:
+
+*   `service_account_ids` (map of strings): A map containing all generated `account_id`s, validated against the 30-character limit. These are ready for use in creating `google_service_account` resources.

--- a/modules/named_sa/README.md
+++ b/modules/named_sa/README.md
@@ -10,22 +10,32 @@ All Service Accounts will adhere to this format:
 
 ### Component Breakdown:
 
-*   **`[domain]`**: Identifies the primary logical grouping, application, or stack (e.g., `apps`, `ml`, `admin`). Abbreviate only if the total name exceeds 30 characters. Ensure consistency in abbreviations. 🧠
-*   **`[component]`**: Describes the specific service, microservice, or function utilizing this SA (e.g., `web-fe`, `data-proc`, `llm-proxy`). **This is the FIRST component to abbreviate** if the total name approaches or exceeds the 30-character limit.
-*   **`[purpose]`**: Indicates the SA's primary role or critical permissions (e.g., `reader`, `invoker`, `admin`). **This is the SECOND component to abbreviate** if shortening `[component]` was insufficient. Use clear abbreviations (`read`, `exec`).
-*   **`[env]`**: Identifies the environment (e.g., `prod`, `stg`, `dev`).
+*   **`[domain]`**: Identifies the primary logical grouping or infrastructure domain (e.g., `github`, `apps`, `ml`, `admin`). This should align with your folder structure domains and represent the top-level organizational boundary. Prioritize semantic clarity over strict abbreviation - the name should be immediately recognizable. 🧠
+*   **`[component]`**: Describes the specific service or functional area within the domain (e.g., `registry`, `web`, `data-proc`, `federation`). This is equivalent to a service configuration file (like `registry.yml` in your stack). **This is the FIRST component to abbreviate** if the total name approaches or exceeds the 30-character limit, but maintain clarity.
+*   **`[purpose]`**: Indicates the specific microservice or primary action/role (e.g., `publish`, `reader`, `invoker`, `admin`). This represents the actual workload or permission scope within the component. **This is the SECOND component to abbreviate** if shortening `[component]` was insufficient. Use clear abbreviations (`read`, `exec`, `pub`).
+*   **`[env]`**: Identifies the environment or access scope (e.g., `prod`, `stg`, `dev`, `public`). This can represent traditional environments or access levels.
 *   **`[suffix]`**: Explicitly marks the resource type based on `sa_type`.
     *   `-sa`: For standard Service Accounts.
-    *   `-federated-user`: For Service Accounts used with Workload Identity Federation.
+    *   `-fa`: For Service Accounts used with Workload Identity Federation.
+
+### Semantic Clarity Priority 📖
+
+The naming convention prioritizes **semantic readability** over strict categorical adherence. The resulting name should read naturally and immediately convey:
+1. What domain/system it belongs to
+2. What service/component it serves  
+3. What specific purpose it fulfills
+4. What environment/scope it operates in
+
+**Example**: `github-artifact-reg-pub-fa` reads as "GitHub artifact registry public federated account" - immediately clear that this is a GitHub federated user that publishes to GCP Artifact Registry.
 
 ### Naming Process:
 
-1.  Draft the full name using all components.
+1.  Draft the full name using all components, prioritizing semantic clarity.
 2.  **Validate the length.** If `<= 30 characters`, proceed.
 3.  **If `> 30 characters`:**
-    1.  Abbreviate `[component]` as much as possible while retaining clarity.
-    2.  If still exceeding 30 characters, then abbreviate `[domain]`.
-    3.  As a final resort, abbreviate `[purpose]`.
+    1.  Abbreviate `[component]` while maintaining clarity (e.g., `registry` → `reg`).
+    2.  If still exceeding 30 characters, then abbreviate `[purpose]` (e.g., `publish` → `pub`).
+    3.  As a final resort, abbreviate `[domain]` (e.g., `github` → `gh`).
 
 ## Enforcement Rules:
 
@@ -41,10 +51,10 @@ Provide a map of your Service Account definitions. This module will return a map
 ## Inputs:
 
 *   `service_accounts` (map of objects): A map of Service Account definitions. Each object requires:
-    *   `domain` (string): The primary logical grouping or application stack
-    *   `component` (string): The specific service or microservice
-    *   `purpose` (string): The Service Account's primary role or permissions
-    *   `env` (string): The environment identifier
+    *   `domain` (string): The primary logical grouping or infrastructure domain
+    *   `component` (string): The specific service or functional area
+    *   `purpose` (string): The specific microservice or primary action/role
+    *   `env` (string): The environment identifier or access scope
     *   `sa_type` (string, optional, default `standard`): Allowed values: `"standard"` or `"federated"`.
     *   `add_suffix_by_this_module` (bool, optional, default `true`): Set to `false` if the suffix is managed externally.
     *   `description` (string, optional): Used for the final `google_service_account` resource's description.

--- a/modules/named_sa/main.tf
+++ b/modules/named_sa/main.tf
@@ -1,7 +1,7 @@
 locals {
   suffix_map = {
     "standard"  = "-sa"
-    "federated" = "-federated-user"
+    "federated" = "-fa"
   }
 
   calculated_account_ids = {

--- a/modules/named_sa/main.tf
+++ b/modules/named_sa/main.tf
@@ -4,10 +4,14 @@ locals {
     "federated" = "-fa"
   }
 
+  calculated_suffixes = {
+    for key, sa_params in var.service_accounts : key => 
+      sa_params.add_suffix_by_this_module ? lookup(local.suffix_map, sa_params.sa_type, "-sa") : ""
+  }
+
   calculated_account_ids = {
     for key, sa_params in var.service_accounts : key => {
-      calculated_suffix = sa_params.add_suffix_by_this_module ? lookup(local.suffix_map, sa_params.sa_type, "-sa") : ""
-      account_id        = "${sa_params.domain}-${sa_params.component}-${sa_params.purpose}-${sa_params.env}${calculated_suffix}"
+      account_id = "${sa_params.domain}-${sa_params.component}-${sa_params.purpose}-${sa_params.env}${local.calculated_suffixes[key]}"
     }
   }
 

--- a/modules/named_sa/main.tf
+++ b/modules/named_sa/main.tf
@@ -1,0 +1,22 @@
+locals {
+  suffix_map = {
+    "standard"  = "-sa"
+    "federated" = "-federated-user"
+  }
+
+  calculated_account_ids = {
+    for key, sa_params in var.service_accounts : key => {
+      calculated_suffix = sa_params.add_suffix_by_this_module ? lookup(local.suffix_map, sa_params.sa_type, "-sa") : ""
+      account_id        = "${sa_params.domain}-${sa_params.component}-${sa_params.purpose}-${sa_params.env}${calculated_suffix}"
+    }
+  }
+
+  validation_result = {
+    for key, config in local.calculated_account_ids : key => {
+      account_id = config.account_id
+      is_valid  = length(config.account_id) <= 30
+    }
+  }
+
+  _validation_check = alltrue([for k, v in local.validation_result : v.is_valid]) ? null : file("ERROR: Service Account ID length validation failed. Review the following IDs that exceed GCP's 30-character limit:\n${join("\n", [for k, v in local.validation_result : !v.is_valid ? "  - '${v.account_id}' (key: '${k}') - ${length(v.account_id)} chars" : ""])}\n\nReview 'domain', 'component', and 'purpose' for required abbreviations in your input, or consider setting 'add_suffix_by_this_module = false' if an external suffix is intended.")
+}

--- a/modules/named_sa/outputs.tf
+++ b/modules/named_sa/outputs.tf
@@ -1,0 +1,21 @@
+output "service_account_ids" {
+  description = "A map of generated service account IDs, validated against GCP's 30-character limit. Use these IDs to create the actual Service Accounts."
+  value = {
+    for key, config in local.calculated_account_ids : key => config.account_id
+  }
+}
+
+output "service_account_configs" {
+  description = "Complete service account configurations including calculated IDs and metadata."
+  value = local.calculated_account_ids
+}
+
+output "validation_summary" {
+  description = "Summary of validation results for all service account IDs."
+  value = {
+    total_accounts = length(local.calculated_account_ids)
+    valid_accounts = length([for k, v in local.validation_result : v if v.is_valid])
+    invalid_accounts = length([for k, v in local.validation_result : v if !v.is_valid])
+    invalid_ids = [for k, v in local.validation_result : v.account_id if !v.is_valid]
+  }
+}

--- a/modules/named_sa/variables.tf
+++ b/modules/named_sa/variables.tf
@@ -1,0 +1,48 @@
+variable "service_accounts" {
+  description = "A map of service account configurations, where keys are logical identifiers for each SA."
+  type = map(object({
+    domain            = string
+    component         = string
+    purpose           = string
+    env               = string
+    description       = optional(string)
+    labels            = optional(map(string))
+    sa_type           = optional(string, "standard")
+    add_suffix_by_this_module = optional(bool, true)
+  }))
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : contains(["standard", "federated-user"], sa_config.sa_type)
+    ])
+    error_message = "Each 'sa_type' must be either 'standard' or 'federated-user'."
+  }
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : length(sa_config.domain) > 0
+    ])
+    error_message = "Domain cannot be empty for any service account."
+  }
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : length(sa_config.component) > 0
+    ])
+    error_message = "Component cannot be empty for any service account."
+  }
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : length(sa_config.purpose) > 0
+    ])
+    error_message = "Purpose cannot be empty for any service account."
+  }
+
+  validation {
+    condition = alltrue([
+      for sa_name, sa_config in var.service_accounts : length(sa_config.env) > 0
+    ])
+    error_message = "Environment cannot be empty for any service account."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,17 @@ variable "landing_identity_provider_id" {
   sensitive   = true
 }
 
+variable "legacy_federated_github_users" {
+  type = map(object({
+    name                 = string
+    display_name         = string
+    description          = string
+    allowed-repositories = list(string)
+  }))
+  description = "The legacy Github users to federate."
+  sensitive   = false
+}
+
 variable "federated_github_users" {
   type = map(object({
     name                 = string
@@ -36,7 +47,21 @@ variable "federated_github_users" {
     description          = string
     allowed-repositories = list(string)
   }))
-  description = "The Github users to federate."
+  description = "The Github users to federate using named_sa module."
+  sensitive   = false
+}
+
+variable "federated_service_accounts" {
+  type = map(object({
+    domain            = string
+    component         = string
+    purpose           = string
+    env               = string
+    description       = string
+    sa_type           = optional(string, "federated")
+    add_suffix_by_this_module = optional(bool, true)
+  }))
+  description = "Federated service accounts using named_sa module."
   sensitive   = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,23 +42,14 @@ variable "legacy_federated_github_users" {
 
 variable "federated_github_users" {
   type = map(object({
-    name                 = string
     display_name         = string
     description          = string
     allowed-repositories = list(string)
-  }))
-  description = "The Github users to federate using named_sa module."
-  sensitive   = false
-}
-
-variable "federated_service_accounts" {
-  type = map(object({
-    domain            = string
-    component         = string
-    purpose           = string
-    env               = string
-    description       = string
-    sa_type           = optional(string, "federated")
+    domain              = string
+    component           = string
+    purpose             = string
+    env                 = string
+    sa_type             = optional(string, "federated")
     add_suffix_by_this_module = optional(bool, true)
   }))
   description = "Federated service accounts using named_sa module."


### PR DESCRIPTION
This pull request introduces enhancements to the handling of federated GitHub users, updates naming conventions for service accounts, and modifies Terraform variables and modules to improve clarity and functionality. The most significant changes include the integration of legacy and new federated GitHub user configurations, updates to naming conventions for service accounts, and adjustments to Terraform modules to support these changes.

### Federated GitHub Users Enhancements:
* Updated `federated-github-users` in `main.tf` to merge legacy federated GitHub users with new configurations, ensuring compatibility and streamlined management. Added a dependency on the `federated_users` module.
* Introduced the `federated_users` module in `main.tf` to dynamically create service accounts for federated GitHub users based on their configurations.
* Added new variables `legacy_federated_github_users` and `federated_github_users` in `variables.tf` to differentiate legacy users from new configurations and support additional attributes like domain, component, and environment.

### Service Account Naming Convention Updates:
* Changed the suffix for federated service accounts from `-federated-user` to `-fa` in `modules/named_sa/main.tf` and updated corresponding documentation in `modules/named_sa/README.md` to emphasize semantic clarity and readability. [[1]](diffhunk://#diff-5408cc3d6ee99512e5bcf4bf06549ef0b0aba78d9b6958eacf8949a331c9896cL4-R4) [[2]](diffhunk://#diff-28eee23209fd764a28b61d591cd365ae76936d42faa7a0309d6e57eb2bc52327L13-R38) [[3]](diffhunk://#diff-28eee23209fd764a28b61d591cd365ae76936d42faa7a0309d6e57eb2bc52327L44-R57)
* Modified the `account_id` logic in `modules/github-identity-federation/federated-github-user/main.tf` to conditionally use the `-fa` suffix based on the `name` attribute.

These changes improve the modularity and clarity of federated user configurations, enhance naming conventions for service accounts, and ensure compatibility with legacy configurations.